### PR TITLE
added missing packages

### DIFF
--- a/PACKAGES
+++ b/PACKAGES
@@ -11,3 +11,5 @@ viridis
 devtools
 leaflet
 shinydashboard
+sqldf
+shinythemes


### PR DESCRIPTION
Our shiny report under visualize-team/example2 uses two packages that aren't installed on the shiny server. Is it ok to add them?