### PR TITLE
Add dependencies for the COVID-19 dashboard

### DIFF
--- a/PACKAGES
+++ b/PACKAGES
@@ -21,3 +21,10 @@ shiny.i18n
 shinyWidgets
 spdplyr
 formattable
+cansim
+ggplot2
+readxl
+scales
+shiny
+shinycssloaders
+tidyverse


### PR DESCRIPTION
This relates to a pull request in the R-dashboards repo (https://github.com/StatCan/R-dashboards/pull/16).