### PR TITLE
Added required packages for RAIS-mobility

### DIFF
--- a/PACKAGES
+++ b/PACKAGES
@@ -45,6 +45,5 @@ ggrepel
 ggthemes
 knitr
 skimr
-shiny.i18n
 circlize
 Cairo

--- a/PACKAGES
+++ b/PACKAGES
@@ -45,3 +45,6 @@ ggrepel
 ggthemes
 knitr
 skimr
+shiny.i18n
+circlize
+Cairo


### PR DESCRIPTION
Added three packages for the [RAIS-mobility app](https://github.com/StatCan/R-dashboards/pull/30).

- circlize and shiny.i18n are downloaded as binaries from CRAN.
- Cairo requires building from the source, but it works without any modifications in the testing.